### PR TITLE
Add syntax-variables.less

### DIFF
--- a/stylesheets/syntax-variables.less
+++ b/stylesheets/syntax-variables.less
@@ -1,0 +1,32 @@
+@import "colors";
+
+// This defines all syntax variables that syntax themes must implement when they
+// include a syntax-variables.less file.
+
+// General colors
+@syntax-text-color: @code-font-color;
+@syntax-cursor-color: @cursor-color;
+@syntax-selection-color: @selected;
+@syntax-selection-flash-color: @search-active-bg;
+@syntax-background-color: @code-background;
+
+// Guide colors
+@syntax-wrap-guide-color: @guides;
+@syntax-indent-guide-color: @guides;
+@syntax-invisible-character-color: @invisible;
+
+// For find and replace markers
+@syntax-result-marker-color: @code-font-color;
+@syntax-result-marker-color-selected: white;
+
+// Gutter colors
+@syntax-gutter-text-color: @gutter-text;
+@syntax-gutter-text-color-selected: @gutter-text-highlight;
+@syntax-gutter-background-color: @gutter-background;
+@syntax-gutter-background-color-selected: @gutter-background-highlight;
+
+// For git diff info. i.e. in the gutter
+@syntax-color-renamed: @blue;
+@syntax-color-added: @green;
+@syntax-color-modified: @yellow;
+@syntax-color-removed: @red;


### PR DESCRIPTION
From Atom's [template guide](https://github.com/atom/template-syntax#notes-and-best-practices):

> Define proper colors in your syntax-variables.less file. Other packages can use these variables. All the variables defined in this package's syntax-variables.less file must be defined — you cannot pick and choose.

This is useful in [markdown preview](https://github.com/atom/markdown-preview/commit/5b4af3a98bb92979a9ab6af3a5f93e8b237f343a), for instance.

Before (block level code in markdown preview)

![image](https://cloud.githubusercontent.com/assets/992008/3926159/e2203778-23ee-11e4-82b3-b402a1c75474.png)

After:

![image](https://cloud.githubusercontent.com/assets/992008/3926173/06ef3cca-23ef-11e4-907a-ce1b06ed9e2f.png)
### Colors I wasn't sure which one would be correct:
- Wasn't sure about `@syntax-selection-flash-color`. I used `@search-active-bg`.
- Wasn't sure about `@syntax-result-marker-color` and `@syntax-result-marker-color-selected`. I used `@code-font-color` and `white`.
- Other colors should be fine.
