### PR TITLE
Make compatible with atom-text-editor shadow DOM

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,13 +1,13 @@
 @import "./stylesheets/colors.less";
 
 // EDITOR BACKGROUND & FONT COLORS
-.editor-colors {
+.editor-colors, :host {
   background-color: @code-background;
   color: @code-font-color;
 }
 
 // MAIN CODE EDITOR STYLES
-.editor {
+.editor, :host {
 
   background-color: @code-background;
   color: @code-font-color;
@@ -107,15 +107,19 @@
 }
 
 // HIGHLIGHT STYLE FOR SEARCH MATCHES
-.editor .search-results .marker .region {
-  background-color: @search-bg;
-  border: @search-border;
+.editor, :host {
+  .search-results .marker .region {
+    background-color: @search-bg;
+    border: @search-border;
+  }
 }
 
 // HIGHLIGHT STYLE FOR CURRENTLY SELECTED SEARCH RESULT
-.editor .search-results .marker.current-result .region {
-  background-color: @search-active-bg;
-  border: @search-active-border;
+.editor, :host {
+  .search-results .marker.current-result .region {
+    background-color: @search-active-bg;
+    border: @search-active-border;
+  }
 }
 
 // COMENTS, DUHR
@@ -560,8 +564,10 @@
   }
 }
 
-.editor.mini .scroll-view {
-  padding-left: 1px;
+.editor.mini, :host(.mini) {
+ .scroll-view {
+    padding-left: 1px;
+  }
 }
 
 


### PR DESCRIPTION
As discussed in our latest [blog post](http://blog.atom.io/2014/11/18/avoiding-style-pollution-with-the-shadow-dom.html), we'll be transitioning Atom's text editor to use the shadow DOM to avoid accidental styling conflicts. Since you have a really popular syntax theme, I thought I'd save you the trouble of reading through our [upgrade guide](https://atom.io/docs/v0.147.0/upgrading/upgrading-your-syntax-theme) and just make the changes for you. Please check to make sure everything works just in case I missed something specific to your theme, but this should be straightforward. Thanks!
