### PR TITLE
Fix bracket matcher styling

### DIFF
--- a/index.less
+++ b/index.less
@@ -567,7 +567,7 @@
 
 // PLUGIN SPECIFIC STYLES
 
-.bracket-matcher {
+.bracket-matcher .region {
   border-bottom: 1px solid @string;
   margin-top: 2px;
 }


### PR DESCRIPTION
See https://github.com/atom/bracket-matcher/pull/82 https://github.com/atom/atom/issues/4453

Now need to style the `.region` inside `.bracket-matcher`.
