### PR TITLE
Remove meta.class scope styling

### DIFF
--- a/index.less
+++ b/index.less
@@ -461,10 +461,6 @@
 }
 
 .meta {
-  & .class {
-    color: @constant;
-  }
-
   &.link {
     color: @meta;
   }


### PR DESCRIPTION
I got tired of staring at the sea of red here.
(This is in D, by the way.)
![d-before](https://cloud.githubusercontent.com/assets/2917145/5591558/86ff34ae-912e-11e4-82eb-207e64596602.png)

After snooping around in the [atom-language-d](https://github.com/amehat/atom-language-d) package and the seti-syntax package, I narrowed the cause down to two snippets of code:
```cson
atom-language-d/grammar/d.cson
---
'name': 'meta.class.d'
```

```less
seti-syntax/index.less
---
.meta {
  & .class {
    color: @constant;
  }
  [...]
}
```
I think there's two problems with this: first the space between the & and the .class (I think this was on accident), and the styling of the meta.class scope (worth milling over).
From what I can gather from the [TextMate documentation on scopes](http://manual.macromates.com/en/language_grammars), it looks like meta isn't really the place to do heavy-duty styling.
> meta — the meta scope is generally used to markup larger parts of the document. For example the entire line which declares a function would be meta.function and the subsets would be storage.type, entity.name.function, variable.parameter etc. and only the latter would be styled.

Plus, both the [C#](https://github.com/atom/language-csharp) and [Java](https://github.com/atom/language-java) packages do the same scoping. I think it's a better choice to alter the syntax highlighting here than to rearrange 3 language syntaxes in order to select only the class line.

**C#**
```cson
language-csharp/grammars/c#.cson
'name': 'meta.class.source.cs'
'name': 'meta.class.identifier.source.cs'
'name': 'meta.class.body.source.cs'
```
![c -before](https://cloud.githubusercontent.com/assets/2917145/5591556/86fe5174-912e-11e4-940b-ba547773723c.png)

**Java**
```cson
language-java/grammars/java.cson
'name': 'meta.class.java'
```
![java-before](https://cloud.githubusercontent.com/assets/2917145/5591557/86ff30ee-912e-11e4-97cb-e05e8a86ae36.png)

I'm not sure what your original intent was, but judging from your stated focus on Javascript and CSS, I think you were specifically going after this scope in the language-javascript package:
```json
language-javascript/javascript.json
---
"comment": "match stuff like: Sound.prototype = { … } when extending an object",
"match": "([a-zA-Z_?.$][\\w?.$]*)\\.(prototype)\\s*(=)\\s*",
"name": "meta.class.js"
```
which would entail styling the .prototype line. After fixing the space error, Javascript looked pretty good to me (image of Bootstrap code)
![javascript](https://cloud.githubusercontent.com/assets/2917145/5591581/6be51a14-9131-11e4-8ebc-f11a08cc98c9.png)
but removing it changed absolutely nothing:
![js-after](https://cloud.githubusercontent.com/assets/2917145/5591587/d89b8864-9131-11e4-86ce-ddbb694d569b.png)

But this also fixed my original D problems (as well as the C# and Java):
![d-after](https://cloud.githubusercontent.com/assets/2917145/5591589/fcf0bd9c-9131-11e4-87f5-f5db65a134d0.png)

Let me know if this is making sense.
