### PR TITLE
Fix line number alignment

### DIFF
--- a/index.less
+++ b/index.less
@@ -40,8 +40,6 @@
       // GUTTER BACKGROUND
       background: @gutter-background;
       color: @gutter-text;
-      padding: 0px;
-
 
       // SELECTED BLOCK
       &.cursor-line {


### PR DESCRIPTION
Tested on Arch Linux x64 (kernel 3.18.2-2), GNOME 3.14.3.

Fixes issue #30.

![Screenshot](https://cloud.githubusercontent.com/assets/2917145/5793558/5b90e1ee-9f0e-11e4-9884-91483befba76.png)

**Versions**:

---

atom: 0.174.0
apm: 0.120.0
npm: 1.4.4
node: 0.10.35
python: 3.4.2
git: 2.2.2