### PR TITLE
Changed font-style to font-weight for bold

### DIFF
--- a/stylesheets/syntax.less
+++ b/stylesheets/syntax.less
@@ -197,7 +197,7 @@
 
     &.bold {
       color: @code-font-color;
-      font-style: bold;
+      font-weight: bold;
     }
 
     &.italic {
@@ -395,7 +395,7 @@
 .markup {
   &.bold {
     color: @markup;
-    font-style: bold;
+    font-weight: bold;
   }
 
   &.changed {


### PR DESCRIPTION
CSS and LESS use the `font-weight` property to make things bold, while `font-style` is solely for italics or oblique.