### PR TITLE
Fixes #3 - C/C++ parenthesis highlighting

### DIFF
--- a/stylesheets/syntax.less
+++ b/stylesheets/syntax.less
@@ -185,9 +185,12 @@
     // QUOTES
     &.string,
     &.variable,
-    &.parameters,
     &.array {
       color: @string;
+    }
+
+    &.parameters {
+      color: @code-font-color;
     }
 
     &.heading,


### PR DESCRIPTION
This fixes the C/C++ parenthesis highlighting issue described in #3 and #19. @jzhu98 has [a PR pending](https://github.com/atom/language-c/pull/62) for the Atom `language-c` repo to address the root cause, but most Atom themes to date set `.punctuation.definition.parameters` to the primary syntax text color, see [`one-dark-syntax`](https://github.com/atom/one-dark-syntax/blob/master/styles/language.less#L104) as an example.