### PR TITLE
Whoops! Seti, caused Atom to crash when using it.

### DIFF
--- a/stylesheets/colors.less
+++ b/stylesheets/colors.less
@@ -29,7 +29,7 @@
 @keyword: @green; // = of var a = b, if of if a = b, px of font-size: 13px;
 @storage: @yellow; // var of var a = b;
 @meta: @code-font-color; // none of border: none;
-@function-param: @blue;;
+@function-param: @blue;
 
 @error: @red;
 
@@ -70,4 +70,4 @@
 @search-active-border: solid 1px @blue;
 
 @search-item-border: @blue;
-@search-item-bg: pink;
+@search-item-bg: @red;


### PR DESCRIPTION
Removed an extra ';' in line 32.
Replaced a 'pink' for the '@red' variable at line 73.
With this corrections seti-syntax should work correctly.