### PR TITLE
fixes #29 - removed hightlight border

### DIFF
--- a/stylesheets/editor.less
+++ b/stylesheets/editor.less
@@ -89,7 +89,6 @@
     // background-color: rgba(230,205,105,0.2);
     // border: solid 1px rgba(230,205,105,0.5);
     background-color: @selected;
-    border: solid 1px @selected-border;
   }
 
 


### PR DESCRIPTION
Not sure if this is the desired fix for #29, but I can't see how we would be able to reliably have a surrounding border for the highlighted region without some overlap.

Now looks like this

![image](https://cloud.githubusercontent.com/assets/4869877/7091852/0a840538-dfa5-11e4-8da8-e9d156d9c357.png)
