### PR TITLE
Improved Python highlighting

### DIFF
--- a/index.less
+++ b/index.less
@@ -8,3 +8,4 @@
 @import "./styles/languages/json.less";
 @import "./styles/languages/mustache.less";
 @import "./styles/languages/go.less";
+@import "./styles/languages/python.less";

--- a/sample-files/Python.py
+++ b/sample-files/Python.py
@@ -17,7 +17,7 @@ for ii in SubFib(10, 200):
         print ii
 
 
-class ThisClass(package.Object):
+class ThisClass(object):
     def __init__(self, *args, **kwargs):
         '''
         Block comments

--- a/sample-files/Python.py
+++ b/sample-files/Python.py
@@ -1,8 +1,28 @@
+import package
+
+
+aClass = package.DefinedClass(3, 4, param1="a string")
+
+
+@package.decorate
 def SubFib(startNumber, endNumber):
-    for cur in F():
-        if cur > endNumber: return
+    for cur in range(endNumber):
+        if cur > endNumber:
+            return
         if cur >= startNumber:
             yield cur
 
-for i in SubFib(10, 200):
-    print i
+for ii in SubFib(10, 200):
+    if aClass.class_method():
+        print ii
+
+
+class ThisClass(package.Object):
+    def __init__(self, *args, **kwargs):
+        '''
+        Block comments
+        '''
+        self.this = "that"
+
+    def is_this_that(self):
+        return True if self.this == "that" else False

--- a/styles/languages/python.less
+++ b/styles/languages/python.less
@@ -1,19 +1,22 @@
 @import "colors";
 
 .source.python {
+
   .class{
     color: @support;
   }
 
+  .support.function.magic,
   .inherited-class{
-      color: darken(@variable, 20%);
+      color: lighten(@variable, 10%);
+      .support.function.builtin.python {
+        // Necessary to highlight the object base class correctly
+        color: lighten(@variable, 10%);
+      }
     }
 
-  .parameter{
-    color: @variable;
-  }
-
-  .storage {
+  .storage,
+  .keyword {
     color: @storage;
   }
 

--- a/styles/languages/python.less
+++ b/styles/languages/python.less
@@ -1,0 +1,29 @@
+@import "colors";
+
+.source.python {
+  .class{
+    color: @support;
+  }
+
+  .inherited-class{
+      color: darken(@variable, 20%);
+    }
+
+  .parameter{
+    color: @variable;
+  }
+
+  .storage {
+    color: @storage;
+  }
+
+  .string{
+    color: @string;
+    &.block{
+      color: darken(@string, 20%);
+      .keyword {
+        color: darken(@string, 20%);
+      }
+    }
+  }
+}

--- a/styles/syntax.less
+++ b/styles/syntax.less
@@ -228,7 +228,7 @@
   }
 
   &.function  {
-    color: @support; // .log of console.log, url of url(http://web.com)
+    color: @entity; // .log of console.log, url of url(http://web.com)
 
     // can't tell what this does :/
     &.any-method {
@@ -327,7 +327,7 @@
   }
 
   &.name.class, &.name.type.class {
-    color: @entity;
+    color: @support;
   }
 
   &.name.section {


### PR DESCRIPTION
Old highlighting
![old](https://cloud.githubusercontent.com/assets/2887977/13860989/4e06a434-ec8b-11e5-9382-4d18d625da53.png)

New highlighting
![new](https://cloud.githubusercontent.com/assets/2887977/13860990/4e0b21e4-ec8b-11e5-995a-2b05850a4d6a.png)

I like this scheme a lot for my JS and HTML work, but I also use Python a lot and it didn't feel very Pythonic, so I added a Python.less file. I find the changes make the code a lot clearer, without changing too much. The main changes are:
* Different highlighting for magic functions
* Highlighting of inherited base classes
* All python statements highlight in yellow (before, some were green).
* Darker block comments
* Extended the python highlighting sample

I also made a change to syntax.less to unify generic class and function highlighting. Now
* .support.class and .entity.name.class highlight as @entity,
* .support.function and .entity.name.function highlight as @support.
Before,
* .support.class and .support.function highlighted as @support (as classes, essentially), and, 
* .entity.name.function and .entity.name.class highlighted as @entity (they both looked like functions