### PR TITLE
Improved jade syntax highlighting. (using language-jade)

### DIFF
--- a/styles/languages/jade.less
+++ b/styles/languages/jade.less
@@ -1,3 +1,8 @@
 .jade {
-
+	.id{
+		color: @color3 !important;
+	}
+	.class{
+		color: @color5 !important;
+	}
 }

--- a/styles/syntax.less
+++ b/styles/syntax.less
@@ -345,6 +345,7 @@ atom-text-editor[mini], :host(.mini) {
   }
 
   &.quoted {
+	color: @string-quoted-double;
     &.double { color: @string-quoted-double; }
     &.single { color: @string-quoted-single; }
   }


### PR DESCRIPTION
This should fix the Jade syntax highlighting issue #7. 
- Ids are now coloured with the same colour as an id in HTML and CSS 
- Class literals i.e. `.class` are given a different colour
- Quoted strings have a default style now, which gets altered if `double` or `single` quoted attributes are added.

Language-jade was used because it provided more complete syntax matching compared to atom-jade.
