### PR TITLE
Improve markdown colors

### DIFF
--- a/index.less
+++ b/index.less
@@ -13,6 +13,7 @@
 @import "styles/languages/mustache";
 @import "styles/languages/python";
 @import "styles/languages/gfm";
+@import "styles/languages/markdown";
 
 // PLUGINS
 @import "styles/plugins/git-time-machine";

--- a/sample-files/Markdown.md
+++ b/sample-files/Markdown.md
@@ -11,7 +11,19 @@ regular paragraph.
 The quick brown fox jumped over the lazy
 dog's back.
 
+# Header 1
+## Header 2
 ### Header 3
+#### Header 4
+##### Header 5
+###### Header 6
+
+This is `inline code`.
+You can *emphasize text* or make it **bold**.
+This is a [website link](http://www.website.com).
+
+- This is a list
+* This is another list
 
 > This is a blockquote.
 >

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -25,6 +25,13 @@
 // TEXT
 @quotes: lighten(@color1, 20);
 @markup: @code-font-color;
+@markup-heading: @orange;
+@markup-h1: @markup-heading;
+@markup-h2: lighten(@markup-heading, 5);
+@markup-h3: lighten(@markup-heading, 10);
+@markup-h4: lighten(@markup-heading, 15);
+@markup-h5: lighten(@markup-heading, 20);
+@markup-h6: lighten(@markup-heading, 25);
 @unknown: @code-font-color;
 
 // MISC COLORS

--- a/styles/languages/gfm.less
+++ b/styles/languages/gfm.less
@@ -3,31 +3,44 @@
 .source.gfm {
   color: @code-font-color;
 
-  .heading {
-    color: @meta-control-flow;
-  }
   .heading-1 {
-    font-weight: bold;
+    color: @markup-h1;
   }
   .heading-2 {
-    font-style: italic;
+    color: @markup-h2;
+  }
+  .heading-3 {
+    color: @markup-h3;
+  }
+  .heading-4 {
+    color: @markup-h4;
+  }
+  .heading-5 {
+    color: @markup-h5;
+  }
+  .heading-6 {
+    color: @markup-h6;
   }
 
   .entity {
     color: @entity-function;
   }
   .link {
-    color: @entity-name-function;
+    color: @green;
+    .entity {
+      color: @purple;
+    }
   }
 
-  .italics {
-    color: @code-font-color;
+  .italic {
+    color: @yellow;
   }
   .bold {
-    color: @code-font-color;
+    color: @yellow;
+    font-weight: bold;
   }
   .variable.list {
-    color: @constant;
+    color: @yellow-highlight;
   }
 
   .hr {
@@ -38,16 +51,10 @@
     color: @string-quoted-single;
   }
 
-  .support.quote {
-    color: @code-background;
-    background-color: @code-font-color;
-  }
-
   .raw {
-    color: @string-quoted-double;
-    border: 1px solid mix(@code-background, @string-quoted-double, 30%);
-    background-color: mix(@code-background, @string-quoted-double, 80%);
+    color: @red;
+    border: 1px solid mix(@code-background, @string-quoted-double, 90%);
+    background-color: mix(@code-background, @string-quoted-double, 90%);
     border-radius: 3px;
   }
-
 }

--- a/styles/languages/markdown.less
+++ b/styles/languages/markdown.less
@@ -1,0 +1,55 @@
+@import "colors";
+
+// Styles for language-markdown package
+.markup.md {
+  .heading-1 {
+    color: @markup-h1;
+  }
+  .heading-2 {
+    color: @markup-h2;
+  }
+  .heading-3 {
+    color: @markup-h3;
+  }
+  .heading-4 {
+    color: @markup-h4;
+  }
+  .heading-5 {
+    color: @markup-h5;
+  }
+  .heading-6 {
+    color: @markup-h6;
+  }
+
+  &.bold {
+    color: @yellow;
+    font-weight: bold;
+  }
+
+  &.italic {
+    color: @yellow;
+    font-style: italic;
+  }
+
+  &.list {
+    .punctuation {
+      color: @yellow-highlight;
+    }
+  }
+
+  &.code, .raw {
+    color: @red;
+    border: 1px solid mix(@code-background, @string-quoted-double, 90%);
+    background-color: mix(@code-background, @string-quoted-double, 90%);
+    border-radius: 3px;
+  }
+
+  &.link {
+    .destination .uri {
+      color: @green;
+    }
+    .string {
+      color: @purple;
+    }
+  }
+}


### PR DESCRIPTION
This PR is aimed to improve markdown colors, possibly solving #114.

**EDIT:** this now works with the syntax you get from both [`language-markdown`][1] and [`language-gfm`][2] package.

Please let me know if you would like me to make some corrections to code or colors, or if you prefer to discard the PR and keep the current markdown style instead.

Preview:
![image](https://cloud.githubusercontent.com/assets/2814672/21463020/9dacb216-c963-11e6-9a22-5ed0c3bc839a.png)

I suppose I can't provide a preview for bold text because of my xubuntu font. 

**Note:** I also created a gist that you could include in your `styles.less` file in case this PR is not accepted: https://gist.github.com/fievelk/e4db668825f8ae4371bbd17564061979
This works with `gfm` as well.

[1]:  https://atom.io/packages/language-markdown
[2]: https://atom.io/packages/language-gfm