### PR TITLE
Fix deprecated CSS selectors

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -1,14 +1,9 @@
 @import "colors";
 
-// EDITOR BACKGROUND & FONT COLORS
-.atom-text-editor, :host {
-  background-color: @code-background;
-  color: @code-font-color;
-}
-
 // MAIN CODE EDITOR STYLES
-.atom-text-editor, :host {
+.atom-text-editor, atom-text-editor {
 
+  // EDITOR BACKGROUND & FONT COLORS
   background-color: @code-background;
   color: @code-font-color;
 

--- a/styles/languages/css.less
+++ b/styles/languages/css.less
@@ -1,3 +1,3 @@
-.source.css {
+.syntax--source.syntax--css {
 
 }

--- a/styles/languages/gfm.less
+++ b/styles/languages/gfm.less
@@ -1,49 +1,49 @@
 @import "colors";
 
-.source.gfm {
+.syntax--source.syntax--gfm {
   color: @code-font-color;
 
-  .heading {
+  .syntax--heading {
     color: @meta-control-flow;
   }
-  .heading-1 {
+  .syntax--heading-1 {
     font-weight: bold;
   }
-  .heading-2 {
+  .syntax--heading-2 {
     font-style: italic;
   }
 
-  .entity {
+  .syntax--entity {
     color: @entity-function;
   }
-  .link {
+  .syntax--link {
     color: @entity-name-function;
   }
 
-  .italics {
+  .syntax--italics {
     color: @code-font-color;
   }
-  .bold {
+  .syntax--bold {
     color: @code-font-color;
   }
-  .variable.list {
+  .syntax--variable.syntax--list {
     color: @constant;
   }
 
-  .hr {
+  .syntax--hr {
     color: @meta-control-flow;
   }
 
-  .comment.quote {
+  .syntax--comment.syntax--quote {
     color: @string-quoted-single;
   }
 
-  .support.quote {
+  .syntax--support.syntax--quote {
     color: @code-background;
     background-color: @code-font-color;
   }
 
-  .raw {
+  .syntax--raw {
     color: @string-quoted-double;
     border: 1px solid mix(@code-background, @string-quoted-double, 30%);
     background-color: mix(@code-background, @string-quoted-double, 80%);

--- a/styles/languages/go.less
+++ b/styles/languages/go.less
@@ -1,3 +1,3 @@
-.go {
+.syntax--go {
 
 }

--- a/styles/languages/html.less
+++ b/styles/languages/html.less
@@ -1,3 +1,3 @@
-.html {
+.syntax--html {
 
 }

--- a/styles/languages/jade.less
+++ b/styles/languages/jade.less
@@ -1,3 +1,3 @@
-.jade {
+.syntax--jade {
 
 }

--- a/styles/languages/javascript.less
+++ b/styles/languages/javascript.less
@@ -1,3 +1,5 @@
-.source.js, .source.ts, .source.jsx {
+.syntax--source.syntax--js,
+.syntax--source.syntax--ts,
+.syntax--source.syntax--jsx {
 
 }

--- a/styles/languages/json.less
+++ b/styles/languages/json.less
@@ -1,22 +1,23 @@
 @import "colors";
 
-.source.json {
-  .meta.structure.dictionary.json {
-    & > .string.quoted.json {
-      & > .punctuation.string {
+.syntax--source.syntax--json {
+  .syntax--meta.syntax--structure.syntax--dictionary.syntax--json {
+    & > .syntax--string.syntax--quoted.syntax--json {
+      & > .syntax--punctuation.syntax--string {
         color: @tag;
       }
       color: @tag;
     }
   }
 
-  .meta.structure.dictionary.json, .meta.structure.array.json {
-    & > .value.json > .string.quoted.json,
-    & > .value.json > .string.quoted.json > .punctuation {
+  .syntax--meta.syntax--structure.syntax--dictionary.syntax--json,
+  .syntax--meta.syntax--structure.syntax--array.syntax--json {
+    & > .syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--json,
+    & > .syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--json > .syntax--punctuation {
       color: @code-font-color;
     }
 
-    & > .constant.language.json {
+    & > .syntax--constant.syntax--language.syntax--json {
       color: @constant;
     }
   }

--- a/styles/languages/mustache.less
+++ b/styles/languages/mustache.less
@@ -1,11 +1,11 @@
 @import "colors";
 
-.mustache {
+.syntax--mustache {
 
-  .meta.tag.template {
+  .syntax--meta.syntax--tag.syntax--template {
     color: @tag;
 
-    .entity.name.tag {
+    .syntax--entity.syntax--name.syntax--tag {
       color: lighten(@tag, 20%);
     }
 

--- a/styles/languages/python.less
+++ b/styles/languages/python.less
@@ -1,30 +1,30 @@
 @import "colors";
 
-.source.python {
+.syntax--source.syntax--python {
 
-  .class{
+  .syntax--class{
     color: @support;
   }
 
-  .support.function.magic,
-  .inherited-class{
+  .syntax--support.syntax--function.syntax--magic,
+  .syntax--inherited-class{
       color: lighten(@variable, 10%);
-      .support.function.builtin.python {
+      .syntax--support.syntax--function.syntax--builtin.syntax--python {
         // Necessary to highlight the object base class correctly
         color: lighten(@variable, 10%);
       }
     }
 
-  .storage,
-  .keyword {
+  .syntax--storage,
+  .syntax--keyword {
     color: @storage;
   }
 
-  .string{
+  .syntax--string{
     color: @string;
-    &.block{
+    &.syntax--block{
       color: darken(@string, 20%);
-      .keyword {
+      .syntax--keyword {
         color: darken(@string, 20%);
       }
     }

--- a/styles/plugins/git-time-machine.less
+++ b/styles/plugins/git-time-machine.less
@@ -1,9 +1,9 @@
 atom-text-editor,
-atom-text-editor::shadow {
+atom-text-editor.editor {
   .line.split-diff-added {
     background: @added !important;
     color: rgba(0,0,0,0.5) !important;
-    .text span, .source span {
+    .syntax--text span, .syntax--source span {
       color: rgba(0,0,0,0.5) !important;
     }
     .indent-guide {
@@ -13,7 +13,7 @@ atom-text-editor::shadow {
   .line.split-diff-removed {
     background: @removed !important;
     color: rgba(255,255,255,0.8) !important;
-    .text span, .source span {
+    .syntax--text span, .syntax--source span {
       color: rgba(255,255,255,0.8) !important;
     }
     .indent-guide {

--- a/styles/syntax.less
+++ b/styles/syntax.less
@@ -1,109 +1,109 @@
 @import "colors";
 
 
-atom-text-editor[mini], :host(.mini) {
+atom-text-editor[mini], atom-text-editor.mini {
  .scroll-view {
     padding-left: 1px;
   }
 }
 
 // MISC
-.text {
+.syntax--text {
   color: @code-font-color;
 }
 
-&.complete_tag {
+&.syntax--complete_tag {
   color: @variable;
 }
 
 
 // COMENTS
-.comment {
+.syntax--comment {
   color: @comment;
   background: @comment-bg;
 }
 
 
 // CONSTANTS
-.constant {
+.syntax--constant {
 
   // true, false, null, undefined
   color: @constant;
 
   // \ of ("what\'s")
-  &.character.escape {
+  &.syntax--character.syntax--escape {
     color: @constant;
   }
 
-  &.name.attribute.tag {
+  &.syntax--name.syntax--attribute.syntax--tag {
     color: @constant-name-attribute-tag;
   }
 
   // all the numbers!
-  &.numeric {
+  &.syntax--numeric {
     color: @numeric;
   }
 
   // can't tell what this does :/
-  &.other.color {
+  &.syntax--other.syntax--color {
     color: @constant;
   }
 
   // can't tell what this does :/
-  &.other.symbol {
+  &.syntax--other.syntax--symbol {
     color: @constant;
   }
 }
 
 
 // ENTITY | exports of module.exports, <div id= of <div id="#id">, . of .className
-.entity {
+.syntax--entity {
 
   color: @entity;
 
 
-  &.name {
+  &.syntax--name {
 
-    &.class, &.type.class {
+    &.syntax--class, &.syntax--type.syntax--class {
       color: @support;
     }
-    &.function {
+    &.syntax--function {
       color: @entity-name-function;
     }
-    &.section {
+    &.syntax--section {
       color: @entity;
     }
-    &.tag {
+    &.syntax--tag {
       color: @entity-name-tag;
       text-decoration: none;
-      &.block, &.inline, &.name {
+      &.syntax--block, &.syntax--inline, &.syntax--name {
         color: @entity-name-tag;
       }
-      &.structure {
+      &.syntax--structure {
         color: @tag;
       }
-      &.block {
+      &.syntax--block {
         color: @tag;
       }
     }
-    &.type {
+    &.syntax--type {
       color: @entity-name-type;
       text-decoration: none;
-      &.tag {
+      &.syntax--tag {
         color: @class;
       }
     }
   }
 
 
-  &.other {
-    &.attribute-name, {
+  &.syntax--other {
+    &.syntax--attribute-name, {
       color: @entity-other-attribute-name;
-      &.id {
+      &.syntax--id {
         color: @entity-other-id;
       }
     }
-    &.inherited-class {
+    &.syntax--inherited-class {
       color: @entity;
     }
   }
@@ -111,39 +111,39 @@ atom-text-editor[mini], :host(.mini) {
 
 
 // INVALID TEXT
-.invalid.illegal, .invalid.deprecated {
+.syntax--invalid.syntax--illegal, .syntax--invalid.syntax--deprecated {
   background: none;
   color: @error;
 }
 
 
 // KEYWORDS
-.keyword {
+.syntax--keyword {
 
   color: @keyword;
 
-  &.control {
+  &.syntax--control {
     color: @keyword-control;
   }
 
-  &.operator {
+  &.syntax--operator {
     color: @keyword-operator;
-    &.assignment {
+    &.syntax--assignment {
       color: @keyword-operator-assignment;
     }
-    &.new {
+    &.syntax--new {
       color: @keyword-operator-new;
     }
   }
 
-  &.other {
-    &.important {
+  &.syntax--other {
+    &.syntax--important {
       color: @keyword-other-important;
     }
-    &.special-method {
+    &.syntax--special-method {
       color: @keyword;
     }
-    &.unit {
+    &.syntax--unit {
       color: @keyword;
     }
   }
@@ -152,154 +152,154 @@ atom-text-editor[mini], :host(.mini) {
 
 
 // MARKUP
-.markup {
-  &.bold {
+.syntax--markup {
+  &.syntax--bold {
     color: @markup;
     font-weight: bold;
   }
 
-  &.changed {
+  &.syntax--changed {
     color: @markup;
   }
 
-  &.deleted {
+  &.syntax--deleted {
     color: @markup;
   }
 
-  &.heading .punctuation.definition.heading {
+  &.syntax--heading .syntax--punctuation.syntax--definition.syntax--heading {
     color: @markup;
   }
 
-  &.inserted {
+  &.syntax--inserted {
     color: @markup;
   }
 
-  &.italic {
+  &.syntax--italic {
     color: @markup;
     font-style: italic;
   }
 
-  &.list {
+  &.syntax--list {
     color: @markup;
   }
 
-  &.quote {
+  &.syntax--quote {
     color: @quotes;
   }
 
-  &.raw.inline {
+  &.syntax--raw.syntax--inline {
     color: @markup;
   }
 }
 
 
 // META
-.meta {
+.syntax--meta {
 
-  &.link {
+  &.syntax--link {
     color: @meta;
   }
 
-  &.require {
+  &.syntax--require {
     color: @meta;
   }
 
 
-  &.brace {
-    &.curly { color: @brackets; }
-    &.round { color: @code-font-color;}
+  &.syntax--brace {
+    &.syntax--curly { color: @brackets; }
+    &.syntax--round { color: @code-font-color;}
   }
 
-  &.control {
-    &.flow {
+  &.syntax--control {
+    &.syntax--flow {
       color: @meta-control-flow;
     }
   }
 
-  &.comma {
+  &.syntax--comma {
     color: @punctuation;
   }
 
-  &.selector {
+  &.syntax--selector {
     color: @punctuation;
   }
 
-  &.separator {
+  &.syntax--separator {
     background-color: @punctuation;
     color: @punctuation;
   }
 
-  &.tag {
+  &.syntax--tag {
     color: @tag;
   }
 }
 
 // NONE
-.none {
+.syntax--none {
   color: @code-font-color;
 }
 
 
 // PUNCTUATION
-.punctuation {
+.syntax--punctuation {
   color: @punctuation;
 
-  &.terminator {
+  &.syntax--terminator {
     color: @punctuation;
   }
 
-  &.separator {
+  &.syntax--separator {
     color: @punctuation-separator;
   }
 
-  &.definition {
+  &.syntax--definition {
 
     color: @punctuation;
 
-    &.array {
+    &.syntax--array {
       color: @punctuation-definition-array;
     }
 
-    &.bold {
+    &.syntax--bold {
       color: @code-font-color;
       font-weight: bold;
     }
 
-    &.comment {
+    &.syntax--comment {
       color: @comment-punc;
     }
 
-    &.heading,
-    &.identity,
-    &.italic {
+    &.syntax--heading,
+    &.syntax--identity,
+    &.syntax--italic {
       color: @code-font-color;
     }
 
-    &.italic {
+    &.syntax--italic {
       font-style: italic;
     }
 
-    &.string {
+    &.syntax--string {
       color: @punctuation-definition-string;
-      &.begin, &.end {
+      &.syntax--begin, &.syntax--end {
         color: @quotes;
       }
     }
 
-    &.variable {
+    &.syntax--variable {
       color: @punctuation-definition-variable;
     }
 
-    &.parameters {
+    &.syntax--parameters {
       color: @code-font-color;
     }
 
-    &.tag {
+    &.syntax--tag {
       color: @tag;
     }
   }
 
-  &.section.embedded {
+  &.syntax--section.syntax--embedded {
     color: @code-font-color;
   }
 
@@ -308,78 +308,78 @@ atom-text-editor[mini], :host(.mini) {
 
 
 // STRINGS
-.string {
+.syntax--string {
   color: @string;
 
-  .constant {
+  .syntax--constant {
     color: @constant;
   }
 
-  &.interpolated {
+  &.syntax--interpolated {
     color: @variable;
   }
 
-  &.regexp {
+  &.syntax--regexp {
 
     // ?:input, select, textarea, button of  /^(?:input|select|textarea|button)$/i,
     color: @regex;
 
-    .constant.character.escape,
-    .source.ruby.embedded,
-    .string.regexp.arbitrary-repitition {
+    .syntax--constant.syntax--character.syntax--escape,
+    .syntax--source.syntax--ruby.syntax--embedded,
+    .syntax--string.syntax--regexp.syntax--arbitrary-repitition {
       color: @regex;
     }
 
-    &.group {
+    &.syntax--group {
       color: @regex;
     }
 
-    &.character-class {
+    &.syntax--character-class {
       color: @regex;
     }
 
-    .source.ruby.embedded {
+    .syntax--source.syntax--ruby.syntax--embedded {
       color: @regex;
     }
 
   }
 
-  &.quoted {
-    &.double { color: @string-quoted-double; }
-    &.single { color: @string-quoted-single; }
+  &.syntax--quoted {
+    &.syntax--double { color: @string-quoted-double; }
+    &.syntax--single { color: @string-quoted-single; }
   }
 
-  .variable {
+  .syntax--variable {
     color: @variable;
   }
 
   // can't tell what this does :/
-  &.other.link {
+  &.syntax--other.syntax--link {
     color: @string;
   }
 }
 
 
-.source {
+.syntax--source {
   color: @color1;
 }
 
 // STORAGE
-.storage {
+.syntax--storage {
   color: @storage;
 
-  &.modifier {
+  &.syntax--modifier {
     color: @storage;
   }
 
-  &.type {
-    &.class {
+  &.syntax--type {
+    &.syntax--class {
       color: @storage-class;
     }
-    &.function {
+    &.syntax--function {
       color: @storage-function;
     }
-    &.var {
+    &.syntax--var {
       color: @storage-var;
     }
   }
@@ -388,58 +388,58 @@ atom-text-editor[mini], :host(.mini) {
 
 
 // SUPPORT
-.support {
+.syntax--support {
 
   color: @support;
 
-  &.class {
+  &.syntax--class {
     color: @support;
   }
 
-  &.function  {
+  &.syntax--function  {
     color: @function;
-    &.decl {
+    &.syntax--decl {
       color: @support-function-decl;
     }
   }
 
-  &.constant {
+  &.syntax--constant {
     color: @constant;
   }
-  &.type {
-    &.property-name {
+  &.syntax--type {
+    &.syntax--property-name {
       color: @support-type-property-name;
     }
   }
 }
 
 // VARIABLES
-.variable {
+.syntax--variable {
   color: @variable;
 
-  &.control.import.include {
+  &.syntax--control.syntax--import.syntax--include {
     color: @variable-import;
   }
 
-  &.other {
+  &.syntax--other {
     color: @variable-other;
 
-    &.property {
+    &.syntax--property {
       color: @variable-other-property;
     }
-    &.module {
+    &.syntax--module {
       color: @variable-other-module;
     }
-    &.module-alias {
+    &.syntax--module-alias {
       color: @variable-other-module-alias;
     }
-    &.object {
+    &.syntax--object {
       color: @variable-other-object;
     }
   }
 
-  &.parameter {
-    &.function {
+  &.syntax--parameter {
+    &.syntax--function {
       color: @obj-method;
     }
   }


### PR DESCRIPTION
This PR is simply doing for `seti-syntax` what jesseweed/seti-ui#379 did for `seti-ui` .