### PR TITLE
remove apmInstallSource, fix #145

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,5 @@
       ],
       "default": "Blue"
     }
-  },
-  "apmInstallSource": {
-    "type": "git",
-    "source": "michbarsinai/seti-syntax",
-    "sha": "fe9b3566f33aa0aa9614e8661e9054aaf753023c"
   }
 }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/13694/23243583/c7c83c32-f9ba-11e6-9ad2-40c41600b1f9.png)

From the screenshot in the latest stable version of atom, it is clear that the `git` commit id shown for installation references back to a very outdated version of `seti-syntax`. The commit id is the same as the one in package.json, so it is easily assumed that newer version of atom actually read from this value even when installing from apm index.

Should fix #145.