### PR TITLE
Fix missing highlighting for unquoted strings

### DIFF
--- a/index.less
+++ b/index.less
@@ -14,6 +14,7 @@
 @import "styles/languages/json";
 @import "styles/languages/markdown";
 @import "styles/languages/mustache";
+@import "styles/languages/perl";
 @import "styles/languages/python";
 
 // PLUGINS

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -95,6 +95,8 @@
 // STRING
 @string-quoted-double: @quotes;
 @string-quoted-single: @quotes;
+@string-unquoted: @quotes;
+@string-other: @string;
 
 @punctuation-definition-array: @string;
 @punctuation-definition-string: @string;

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -62,6 +62,7 @@
 @constant: @color3; // true of var x = true, {{}} of {{> hbs_include}}
 @entity: @color5; // exports of module.exports, <div id= of <div id="#id">, . of .className
 @entity-function: @color5;
+@error-punc: darken(@error, 20%);
 @function: @entity-function;
 @function-param: @color1; // (one, two, three) of function (one, two, three)
 @meta: @code-font-color; // none of border: none;

--- a/styles/languages/perl.less
+++ b/styles/languages/perl.less
@@ -13,5 +13,9 @@
         color: @punctuation;
       }
     }
+
+    .syntax--invalid.syntax--illegal.syntax--whitespace {
+      background-color: @error;
+    }
   }
 }

--- a/styles/languages/perl.less
+++ b/styles/languages/perl.less
@@ -1,0 +1,17 @@
+@import "colors";
+
+.syntax--source.syntax--perl {
+
+  .syntax--pod {
+    &.syntax--displayed-text {
+      color: @constant;
+    }
+
+    &.syntax--inline.syntax--tag {
+      .syntax--punctuation.syntax--begin,
+      .syntax--punctuation.syntax--end {
+        color: @punctuation;
+      }
+    }
+  }
+}

--- a/styles/languages/perl.less
+++ b/styles/languages/perl.less
@@ -7,6 +7,12 @@
       color: @constant;
     }
 
+    &.syntax--constant.syntax--character.syntax--entity {
+      &, & .syntax--entity.syntax--name {
+        color: @constant;
+      }
+    }
+
     &.syntax--inline.syntax--tag {
       .syntax--punctuation.syntax--begin,
       .syntax--punctuation.syntax--end {

--- a/styles/languages/perl.less
+++ b/styles/languages/perl.less
@@ -19,9 +19,5 @@
         color: @punctuation;
       }
     }
-
-    .syntax--invalid.syntax--illegal.syntax--whitespace {
-      background-color: @error;
-    }
   }
 }

--- a/styles/syntax.less
+++ b/styles/syntax.less
@@ -349,6 +349,14 @@ atom-text-editor[mini], atom-text-editor.mini {
     &.syntax--single { color: @string-quoted-single; }
   }
 
+  &.syntax--unquoted {
+    color: @string-unquoted;
+  }
+
+  &.syntax--other {
+    color: @string-other;
+  }
+
   .syntax--variable {
     color: @variable;
   }

--- a/styles/syntax.less
+++ b/styles/syntax.less
@@ -351,6 +351,11 @@ atom-text-editor[mini], atom-text-editor.mini {
 
   &.syntax--unquoted {
     color: @string-unquoted;
+    &.syntax--heredoc, &.syntax--here-doc,
+    &.syntax--nowdoc, &.syntax--now-doc,
+    &.syntax--block, &.syntax--program-block {
+      color: @string;
+    }
   }
 
   &.syntax--other {

--- a/styles/syntax.less
+++ b/styles/syntax.less
@@ -114,6 +114,14 @@ atom-text-editor[mini], atom-text-editor.mini {
 .syntax--invalid.syntax--illegal, .syntax--invalid.syntax--deprecated {
   background: none;
   color: @error;
+
+  &.syntax--whitespace {
+    background-color: @error;
+  }
+
+  .syntax--punctuation {
+    color: @error-punc;
+  }
 }
 
 


### PR DESCRIPTION
This has been missing in `seti-syntax` for a long time, and it's really made it harder to make syntax highlighting for config files look appealing to Seti users... 😞 

Here's a before-and-after:

![figure-1](https://user-images.githubusercontent.com/2346707/28493030-255308fc-6f52-11e7-8556-984da7e4c152.gif)

"Unquoted" strings are basically any line (or block) of text that's interpreted as one long string without needing quotation marks. It's drawn from [TextMate's conventions](http://manual.macromates.com/en/language_grammars#naming_conventions) for scope-names in language grammars.