### PR TITLE
Move `.source` styling to the top of stylesheet

### DIFF
--- a/styles/syntax.less
+++ b/styles/syntax.less
@@ -237,7 +237,6 @@ atom-text-editor[mini], atom-text-editor.mini {
   }
 
   &.syntax--separator {
-    background-color: @punctuation;
     color: @punctuation;
   }
 

--- a/styles/syntax.less
+++ b/styles/syntax.less
@@ -8,6 +8,10 @@ atom-text-editor[mini], atom-text-editor.mini {
 }
 
 // MISC
+.syntax--source {
+  color: @color1;
+}
+
 .syntax--text {
   color: @code-font-color;
 }
@@ -380,10 +384,6 @@ atom-text-editor[mini], atom-text-editor.mini {
   }
 }
 
-
-.syntax--source {
-  color: @color1;
-}
 
 // STORAGE
 .syntax--storage {


### PR DESCRIPTION
This solves a whacky styling issue where the `.source` scope receives styling before `.comment` does, leading to some bizarre block-comments:

<table><tr><td><img src="https://user-images.githubusercontent.com/2346707/38171592-d4776ae0-35df-11e8-8eb5-cc1095fb0039.png" width="178" alt="Figure 1: Before" /></td><td><img src="https://user-images.githubusercontent.com/2346707/38171608-f40615aa-35df-11e8-98b5-d505dbb730e8.png" width="178" alt="Figure 2: After" /></td><tr><td align="center"><b>Before</b></td><td align="center"><b>After</b></td></tr></table>

I strongly recommend cutting a release after merging this, BTW. The fixes made in my earlier PR (#156) are still pending publication. 😛 